### PR TITLE
Implement JSON Schema Guardrail

### DIFF
--- a/mediation/ai/json-schema-guardrail/universal-gw/README.md
+++ b/mediation/ai/json-schema-guardrail/universal-gw/README.md
@@ -1,0 +1,164 @@
+# JSON Schema Guardrail Mediator for WSO2 API Manager Universal Gateway
+
+The **JSON Schema Guardrail** is a custom Synapse mediator for **WSO2 API Manager Universal Gateway**, designed to validate JSON payloads against a user-defined **JSON Schema**. This mediator enables API publishers to enforce structural and content compliance dynamically in both request and response flows.
+
+---
+
+## ✨ Features
+
+- ✅ Validate payload structure and fields using **JSON Schema**
+- ✅ Target specific segments of a payload using **JSONPath**
+- ✅ Support for **inverted validation** (fail when schema matches)
+- ✅ **Guardrail assessment** for better observability on violations
+- ✅ Works on both **request and response** flows
+- ✅ Integrates with WSO2 **fault sequences** on failure
+
+---
+
+## 🛠️ Prerequisites
+
+- Java 11 (JDK)
+- Maven 3.6.x or later
+- WSO2 API Manager or Synapse-compatible runtime
+
+---
+
+## 📦 Building the Project
+
+To compile and package the mediator:
+
+```bash
+mvn clean install
+```
+
+> ℹ️ This will generate a `.zip` file in the `target/` directory containing the mediator JAR, `policy-definition.json`, and `artifact.j2`.
+
+---
+
+## 🚀 How to Use
+
+Follow these steps to integrate the JSON Schema Guardrail policy into your WSO2 API Manager instance:
+
+1. **Unzip the Build Artifact**
+
+```bash
+unzip target/org.wso2.apim.policies.mediation.ai.json-schema-guardrail-<version>-distribution.zip -d json-schema-guardrail
+```
+
+2. **Copy the Mediator JAR**
+
+```bash
+cp json-schema-guardrail/org.wso2.apim.policies.mediation.ai.json-schema-guardrail-<version>.jar $APIM_HOME/repository/components/lib/
+```
+
+3. **Register the Policy in Publisher**
+
+- Use the `policy-definition.json` and `artifact.j2` files to define the policy in the Publisher Portal.
+- Place them in your custom policy deployment directory or register them using the Admin REST API.
+
+4. **Apply and Deploy the Policy**
+
+- Go to **API Publisher**
+- Select your API
+- Navigate to **Runtime > Request/Response Flow**
+- Click **Add Policy** and choose **JSON Schema Guardrail**
+- Drag and drop the policy into the response flow
+- Configure the policy parameters (name, JSONPath, schema, etc.)
+- **Save and Deploy** the API
+
+---
+
+## 🧾 Example Policy Configuration
+
+1. Create an AI API using Mistral AI.
+2. Add the JSON Schema Guardrail policy to the API with the following configuration:
+
+| Field                       | Example                        |
+|-----------------------------|--------------------------------|
+| `Guardrail Name`            | `Form Validator`               |
+| `JSON Path`                 | `$.choices[0].message.content` |
+| `Invert the Decision`       | `false`                        |
+| `Show Guardrail Assessment` | `false`                        |
+
+`JSON Schema`
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "fullName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "phoneNumber": {
+      "type": "string",
+      "pattern": "^\\+?[0-9\\-\\s]{7,20}$"
+    },
+    "organization": {
+      "type": "string",
+      "minLength": 1
+    },
+    "preferredPlan": {
+      "type": "string",
+      "enum": ["Free", "Pro", "Enterprise"]
+    },
+    "referralCode": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": ["fullName", "email"],
+  "additionalProperties": false
+}
+```
+
+
+3. Save and re-deploy the API.
+4. Invoke the API's `chat/completion` endpoint with a prompt that will generate a response that violates the enforced schema.
+
+```json
+{
+  "model": "mistral-large-latest",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Extract the following fields from the given text and return a JSON object matching this format:\n\n{\n  \"fullName\": \"string\",\n  \"email\": \"string\",\n  \"phoneNumber\": \"string\",\n  \"organization\": \"string\",\n  \"preferredPlan\": \"Free | Pro | Enterprise\",\n  \"referralCode\": \"string\"\n}\n\nOnly include the keys that are present in the input. The JSON should not contain any extra text or explanation.\n\nInput:\nPlease register a new client with the following details:\n\n- Full Name: John Doe\n- - Phone Number: +1-555-123-4567\n- Organization: Acme Corp\n- Preferred Plan: Enterprise\n- Referral Code: ACME2025"
+    }
+  ]
+}
+```
+
+The following guardrail error response will be returned with http status code `446`:
+
+```json
+{
+  "code": "900514",
+  "type": "JSON_SCHEMA_GUARDRAIL",
+  "message": {
+    "interveningGuardrail": "Form Validator",
+    "action": "GUARDRAIL_INTERVENED",
+    "actionReason": "Violation of enforced JSON schema detected.",
+    "direction": "RESPONSE"
+  }
+}
+```
+
+---
+
+## ⚠️ Limitations
+
+The **JSON Schema Guardrail** uses the following regular expression to extract json portions from the inspected content:
+
+```regex
+\{.*?\}
+```
+
+This pattern is designed to extract **JSON objects only**; **JSON arrays are not supported**.
+
+> 🔒 If at least one JSON object match is found, mediation will proceed.
+If no JSON object match is found, the guardrail will intervene and block the mediation flow.
+---

--- a/mediation/ai/json-schema-guardrail/universal-gw/json-schema-guardrail/assembly-zip.xml
+++ b/mediation/ai/json-schema-guardrail/universal-gw/json-schema-guardrail/assembly-zip.xml
@@ -1,0 +1,27 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <!-- Include the JAR -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+        <!-- Include the ../resources directory -->
+        <fileSet>
+            <directory>${basedir}/../resources</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/mediation/ai/json-schema-guardrail/universal-gw/json-schema-guardrail/pom.xml
+++ b/mediation/ai/json-schema-guardrail/universal-gw/json-schema-guardrail/pom.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.apim.policies</groupId>
+    <artifactId>org.wso2.apim.policies.mediation.ai.json-schema-guardrail</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 APIM Mediation Policies - JSON Schema Guardrail</name>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <org.apache.felix.version>3.3.0</org.apache.felix.version>
+        <synapse.version>4.0.0-wso2v131</synapse.version>
+        <commons-lang3.version>3.13.0</commons-lang3.version>
+        <jackson.version>2.19.0</jackson.version>
+        <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
+        <json.orbit.version>3.0.0.wso2v6</json.orbit.version>
+        <everit-json-schema.version>1.14.5</everit-json-schema.version>
+        <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
+        <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
+    </properties>
+
+    <dependencies>
+        <!-- Synapse Dependencies -->
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>${synapse.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
+
+        <!-- Jackson for JSON Processing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- JSON Library -->
+        <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.orbit.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${com.jayway.jsonpath.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
+            <version>${everit-json-schema.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${org.apache.felix.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.wso2.apim.policies.mediation.ai.json.schema.guardrail;version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            !org.apache.commons.lang3.*,
+                            !com.jayway.jsonpath.*,
+                            !net.minidev.json.*,
+                            !net.minidev.asm.*,
+                            !org.json.*,
+                            !com.github.erosb.*,
+                            org.apache.axis2; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.description; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.engine; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.rpc.receivers; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.context; version="${axis2.osgi.version.range}",
+                            org.apache.commons.logging.*; version="${import.package.version.commons.logging}",
+                            org.apache.synapse,
+                            org.apache.synapse.config,
+                            org.apache.synapse.config.xml,
+                            org.apache.synapse.core,
+                            org.apache.synapse.core.axis2,
+                            org.apache.synapse.mediators.base,
+                            org.apache.axis2.transport.base,
+                            org.apache.synapse.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>
+                            json;scope=compile|runtime,
+                            json-path;scope=compile|runtime,
+                            everit-json-schema;scope=compile|runtime,
+                            commons-lang3;scope=compile|runtime
+                        </Embed-Dependency>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase> <!-- Runs after the JAR is built -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly-zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+</project>

--- a/mediation/ai/json-schema-guardrail/universal-gw/json-schema-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/json/schema/guardrail/JSONSchemaGuardrail.java
+++ b/mediation/ai/json-schema-guardrail/universal-gw/json-schema-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/json/schema/guardrail/JSONSchemaGuardrail.java
@@ -1,0 +1,301 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.json.schema.guardrail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.AbstractMediator;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONObject;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * JSON Schema Guardrail mediator.
+ * <p>
+ * A Synapse mediator that validates incoming JSON payloads against a specified JSON Schema.
+ * Supports selective validation using JsonPath expressions and inversion logic to determine
+ * blocking conditions. Designed to enforce data quality and compliance checks at API gateway level.
+ * <p>
+ * If the payload fails validation (or passes when inversion is enabled), the mediator
+ * triggers a configured fault sequence to handle the violation.
+ */
+public class JSONSchemaGuardrail extends AbstractMediator implements ManagedLifecycle {
+    private static final Log logger = LogFactory.getLog(JSONSchemaGuardrail.class);
+
+    private String name;
+    private String schema;
+    private String jsonPath = "";
+    private boolean invert = false;
+    private boolean showAssessment = false;
+    private Schema schemaObj;
+
+    /**
+     * Initializes the JSONSchemaGuardrail mediator.
+     *
+     * @param synapseEnvironment The Synapse environment instance.
+     */
+    @Override
+    public void init(SynapseEnvironment synapseEnvironment) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Initializing JSONSchemaGuardrail");
+        }
+    }
+
+    /**
+     * Destroys the JSONSchemaGuardrail mediator instance and releases any allocated resources.
+     */
+    @Override
+    public void destroy() {
+        // No specific resources to release
+    }
+
+    /**
+     * Executes the JSON schema validation logic against the incoming message payload.
+     * <p>
+     * If the payload fails validation (or passes, when inverted), a fault sequence is triggered,
+     * and the mediation flow is interrupted.
+     *
+     * @param messageContext The Synapse message context containing the payload.
+     * @return {@code true} to continue mediation flow, {@code false} to invoke a fault sequence.
+     */
+    @Override
+    public boolean mediate(MessageContext messageContext) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Beginning guardrail evaluation.");
+        }
+
+        try {
+            boolean doTriggerGuardrailError = validatePayload(messageContext);
+
+            if (doTriggerGuardrailError) {
+                // Set error properties in message context
+                messageContext.setProperty(SynapseConstants.ERROR_CODE,
+                        JSONSchemaGuardrailConstants.GUARDRAIL_APIM_EXCEPTION_CODE);
+                messageContext.setProperty(JSONSchemaGuardrailConstants.ERROR_TYPE,
+                        JSONSchemaGuardrailConstants.JSON_SCHEMA_GUARDRAIL);
+                messageContext.setProperty(JSONSchemaGuardrailConstants.CUSTOM_HTTP_SC,
+                        JSONSchemaGuardrailConstants.GUARDRAIL_ERROR_CODE);
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Triggering configured fault sequence.");
+                }
+
+                Mediator faultMediator = messageContext.getSequence(JSONSchemaGuardrailConstants.FAULT_SEQUENCE_KEY);
+                if (faultMediator == null) {
+                    messageContext.setProperty(SynapseConstants.ERROR_MESSAGE,
+                            "Violation of " + name + " detected.");
+                    faultMediator = messageContext.getFaultSequence(); // Fall back to default error sequence
+                }
+
+                faultMediator.mediate(messageContext);
+                return false; // Stop further processing
+            }
+        } catch (Exception e) {
+            logger.error("Error during guardrail mediation.", e);
+
+            messageContext.setProperty(SynapseConstants.ERROR_CODE,
+                    JSONSchemaGuardrailConstants.APIM_INTERNAL_EXCEPTION_CODE);
+            messageContext.setProperty(SynapseConstants.ERROR_MESSAGE,
+                    "Error occurred during JSONSchemaGuardrail mediation");
+            Mediator faultMediator = messageContext.getFaultSequence();
+            faultMediator.mediate(messageContext);
+            return false; // Stop further processing
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates the extracted JSON content against the configured schema.
+     *
+     * @param messageContext The Synapse message context.
+     * @return {@code true} if the payload matches the schema; otherwise, {@code false}.
+     */
+    private boolean validatePayload(MessageContext messageContext) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Validating extracted JSON payload.");
+        }
+
+        String jsonContent = extractJsonContent(messageContext);
+        if (StringUtils.isBlank(jsonContent)) {
+            return false;
+        }
+
+        // If no JSON path is specified, apply regex to the entire JSON content
+        if (jsonPath == null || jsonPath.trim().isEmpty()) {
+            return validateJsonAgainstSchema(jsonContent, messageContext);
+        }
+
+        // Check if any extracted value by json path matches the regex pattern
+        return validateJsonAgainstSchema(JsonPath.read(jsonContent, jsonPath).toString(), messageContext);
+    }
+
+    /**
+     * Performs JSON Schema validation on the provided input string.
+     *
+     * @param input The JSON string to validate.
+     * @return {@code true} if a valid match is found; otherwise, {@code false}.
+     */
+    private boolean validateJsonAgainstSchema(String input, MessageContext messageContext) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Executing schema validation on input.");
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Pattern pattern = Pattern.compile(JSONSchemaGuardrailConstants.JSON_CONTENT_REGEX, Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(input);
+
+        boolean matchedAndValid = false;
+
+        while (matcher.find()) {
+            String candidate = matcher.group(0);
+            try {
+                String unescapedCandidate = StringEscapeUtils.unescapeJava(candidate);
+                JsonNode node = objectMapper.readTree(unescapedCandidate);
+                schemaObj.validate(new JSONObject(node.toString()));
+                matchedAndValid =  true;
+                break; // Exit loop on first valid match
+            } catch (Exception ignore) {
+                // Continue to next match
+            }
+        }
+
+        boolean finalResult = invert != matchedAndValid;
+        if (!finalResult) {
+            // Early build assessment details
+            String assessmentObject = buildAssessmentObject(input, messageContext.isResponse());
+            messageContext.setProperty(SynapseConstants.ERROR_MESSAGE, assessmentObject);
+        }
+
+        return !finalResult;
+    }
+
+    /**
+     * Extracts the full JSON payload from the message context.
+     *
+     * @param messageContext The Synapse message context.
+     * @return The JSON content as a string, or {@code null} if unavailable.
+     */
+    private String extractJsonContent(MessageContext messageContext) {
+        org.apache.axis2.context.MessageContext axis2MC =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        return JsonUtil.jsonPayloadToString(axis2MC);
+    }
+
+    /**
+     * Builds a JSON object containing assessment details from the guardrail response.
+     * This creates a structured representation of the guardrail findings to be included
+     * in error messages or for logging purposes.
+     *
+     * @return A JSON string containing assessment details and guardrail action information
+     */
+    private String buildAssessmentObject(String content, boolean isResponse) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Building guardrail assessment object.");
+        }
+
+        JSONObject assessmentObject = new JSONObject();
+
+        assessmentObject.put(JSONSchemaGuardrailConstants.ASSESSMENT_ACTION, "GUARDRAIL_INTERVENED");
+        assessmentObject.put(JSONSchemaGuardrailConstants.INTERVENING_GUARDRAIL, name);
+        assessmentObject.put(JSONSchemaGuardrailConstants.DIRECTION, isResponse? "RESPONSE" : "REQUEST");
+        assessmentObject.put(JSONSchemaGuardrailConstants.ASSESSMENT_REASON,
+                "Violation of enforced JSON schema detected.");
+
+        if (showAssessment) {
+            String message = "The inspected response payload content: " + content
+                    + " does not satisfy the JSON schema: " + schema;
+            assessmentObject.put(JSONSchemaGuardrailConstants.ASSESSMENTS, message);
+        }
+        return assessmentObject.toString();
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getSchema() {
+
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+
+        this.schema = schema;
+        schemaObj = SchemaLoader.load(new JSONObject(schema));
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Schema compiled successfully: " + schema);
+        }
+    }
+
+    public String getJsonPath() {
+
+        return jsonPath;
+    }
+
+    public void setJsonPath(String jsonPath) {
+
+        this.jsonPath = jsonPath;
+    }
+
+    public boolean isInvert() {
+
+        return invert;
+    }
+
+    public void setInvert(boolean invert) {
+
+        this.invert = invert;
+    }
+
+    public boolean isShowAssessment() {
+
+        return showAssessment;
+    }
+
+    public void setShowAssessment(boolean showAssessment) {
+
+        this.showAssessment = showAssessment;
+    }
+}

--- a/mediation/ai/json-schema-guardrail/universal-gw/json-schema-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/json/schema/guardrail/JSONSchemaGuardrailConstants.java
+++ b/mediation/ai/json-schema-guardrail/universal-gw/json-schema-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/json/schema/guardrail/JSONSchemaGuardrailConstants.java
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.json.schema.guardrail;
+
+public class JSONSchemaGuardrailConstants {
+    public static final int GUARDRAIL_ERROR_CODE = 446;
+    public static final int APIM_INTERNAL_EXCEPTION_CODE = 900967;
+    public static final int GUARDRAIL_APIM_EXCEPTION_CODE = 900514;
+    public static final String ERROR_TYPE = "ERROR_TYPE";
+    public static final String JSON_SCHEMA_GUARDRAIL = "JSON_SCHEMA_GUARDRAIL";
+    public static final String CUSTOM_HTTP_SC = "CUSTOM_HTTP_SC";
+    public static final String FAULT_SEQUENCE_KEY = "guardrail_fault";
+    public static final String JSON_CONTENT_REGEX = "\\{.*?\\}";
+    public static final String TEXT_CLEAN_REGEX = "^\"|\"$";
+
+    public static final String ASSESSMENT_ACTION = "action";
+    public static final String INTERVENING_GUARDRAIL = "interveningGuardrail";
+    public static final String DIRECTION = "direction";
+    public static final String ASSESSMENT_REASON = "actionReason";
+    public static final String ASSESSMENTS = "assessments";
+}

--- a/mediation/ai/json-schema-guardrail/universal-gw/resources/artifact.j2
+++ b/mediation/ai/json-schema-guardrail/universal-gw/resources/artifact.j2
@@ -1,0 +1,7 @@
+<class name="org.wso2.apim.policies.mediation.ai.json.schema.guardrail.JSONSchemaGuardrail">
+    <property action="set" name="name" value="{{name}}"/>
+    <property action="set" name="schema" value="{{schema}}"/>
+    <property action="set" name="jsonPath" value="{{jsonPath}}"/>
+    <property action="set" name="invert" type="BOOLEAN" value="{{invert}}"/>
+    <property action="set" name="showAssessment" type="BOOLEAN" value="{{showAssessment}}"/>
+</class>

--- a/mediation/ai/json-schema-guardrail/universal-gw/resources/policy-definition.json
+++ b/mediation/ai/json-schema-guardrail/universal-gw/resources/policy-definition.json
@@ -1,0 +1,63 @@
+{
+  "category": "Mediation",
+  "name": "JSONSchemaGuardrail",
+  "displayName": "JSON Schema Guardrail",
+  "version": "v1.0",
+  "description": "Validate the request or response to contain a JSON that adheres to a defined schema",
+  "applicableFlows": [
+    "request",
+    "response"
+  ],
+  "supportedApiTypes": [
+    {
+      "subType": "AIAPI",
+      "apiType": "HTTP"
+    }
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "policyAttributes": [
+    {
+      "name": "name",
+      "displayName": "Guardrail Name",
+      "description": "The name of the guardrail policy. This will be used for tracking purposes.",
+      "type": "String",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "schema",
+      "displayName": "JSON Schema",
+      "description": "The JSON Schema used to validate the structure of the content.",
+      "required": true,
+      "type": "JSON",
+      "allowedValues": []
+    },
+    {
+      "name": "jsonPath",
+      "displayName": "JSON Path",
+      "description": "The JSONPath expression used to extract content from the payload. If not specified, the entire payload will be used for validation.",
+      "type": "String",
+      "allowedValues": [],
+      "required": false
+    },
+    {
+      "name": "invert",
+      "displayName": "Invert the Decision",
+      "description": "Inverts the guardrail decision so that it fails if the content matches the defined schema.",
+      "required": false,
+      "type": "Boolean",
+      "allowedValues": []
+    },
+    {
+      "name": "showAssessment",
+      "displayName": "Show Guardrail Assessment",
+      "description": "When enabled, the error response will include detailed information about the reason for the guardrail intervention.",
+      "type": "Boolean",
+      "defaultValue": "false",
+      "allowedValues": [],
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
To implement a mediation policy that serves as a url validation guardrail within the API Gateway.

## Approach
Develop a custom Synapse mediator that validates specific parts of a JSON payload—extracted using a JSONPath expression—against a predefined JSON Schema. This policy can be applied to both request and response flows and enforces structural compliance by rejecting traffic when the extracted content does not conform to the specified schema.
