### PR TITLE
Implement Prompt Decorator Policy

### DIFF
--- a/mediation/ai/prompt-decorator/universal-gw/prompt-decorator/assembly-zip.xml
+++ b/mediation/ai/prompt-decorator/universal-gw/prompt-decorator/assembly-zip.xml
@@ -1,0 +1,27 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <!-- Include the JAR -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+        <!-- Include the ../resources directory -->
+        <fileSet>
+            <directory>${basedir}/../resources</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/mediation/ai/prompt-decorator/universal-gw/prompt-decorator/pom.xml
+++ b/mediation/ai/prompt-decorator/universal-gw/prompt-decorator/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.apim.policies</groupId>
+    <artifactId>org.wso2.apim.policies.mediation.ai.prompt-decorator</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 APIM Mediation Policies - AI Prompt Decorator</name>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <org.apache.felix.version>3.3.0</org.apache.felix.version>
+        <synapse.version>4.0.0-wso2v131</synapse.version>
+        <jackson.version>2.19.0</jackson.version>
+        <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
+        <json.orbit.version>3.0.0.wso2v6</json.orbit.version>
+        <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
+        <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
+    </properties>
+
+    <dependencies>
+        <!-- Synapse Dependencies -->
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>${synapse.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jackson for JSON Processing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- JSON Library -->
+        <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.orbit.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${com.jayway.jsonpath.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${org.apache.felix.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.wso2.apim.policies.mediation.ai.prompt.decorator;version="${project.version}",
+                        </Export-Package>
+                        <Import-Package>
+                            !com.jayway.jsonpath.*,
+                            !net.minidev.json.*,
+                            !net.minidev.asm.*,
+                            !org.json.*,
+                            org.apache.axis2; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.description; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.engine; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.rpc.receivers; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.context; version="${axis2.osgi.version.range}",
+                            org.apache.commons.logging.*; version="${import.package.version.commons.logging}",
+                            org.apache.synapse,
+                            org.apache.synapse.config,
+                            org.apache.synapse.config.xml,
+                            org.apache.synapse.core,
+                            org.apache.synapse.core.axis2,
+                            org.apache.synapse.mediators.base,
+                            org.apache.axis2.transport.base,
+                            org.apache.synapse.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>
+                            json;scope=compile|runtime,
+                            json-path;scope=compile|runtime
+                        </Embed-Dependency>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase> <!-- Runs after the JAR is built -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly-zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+</project>

--- a/mediation/ai/prompt-decorator/universal-gw/prompt-decorator/src/main/java/org/wso2/apim/policies/mediation/ai/prompt/decorator/PromptDecorator.java
+++ b/mediation/ai/prompt-decorator/universal-gw/prompt-decorator/src/main/java/org/wso2/apim/policies/mediation/ai/prompt/decorator/PromptDecorator.java
@@ -1,0 +1,255 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.prompt.decorator;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.TypeRef;
+import org.apache.axis2.AxisFault;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.AbstractMediator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * PromptDecorator mediator.
+ * <p>
+ * A mediator that decorates specific parts of a JSON payload by either prepending or appending
+ * content at a specified JSONPath location.
+ * <p>
+ * Supports modifying string fields or array fields based on the provided configuration.
+ * Designed for use cases such as enhancing AI prompts or modifying request/response payloads dynamically.
+ */
+public class PromptDecorator extends AbstractMediator implements ManagedLifecycle {
+    private static final Log logger = LogFactory.getLog(PromptDecorator.class);
+
+    private String name;
+    private String promptDecoratorConfig;
+    private boolean append = false;
+    private String jsonPath;
+    private PromptDecoratorConstants.DecorationType type;
+    private String decoration;
+
+    /**
+     * Initializes the PromptDecorator mediator.
+     *
+     * @param synapseEnvironment The Synapse environment instance.
+     */
+    @Override
+    public void init(SynapseEnvironment synapseEnvironment) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Initializing PromptDecorator.");
+        }
+    }
+
+    /**
+     * Destroys the PromptTemplate mediator instance and releases any allocated resources.
+     */
+    @Override
+    public void destroy() {
+        // No specific resources to release
+    }
+
+    /**
+     * Executes the PromptDecorator mediation logic.
+     * <p>
+     * Locates the target JSON field using JSONPath and applies the configured decoration.
+     *
+     * @param messageContext The message context containing the JSON payload.
+     * @return {@code true} to continue mediation flow.
+     */
+    @Override
+    public boolean mediate(MessageContext messageContext) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Mediating message context with prompt decorator.");
+        }
+
+        try {
+            findAndTransformPayload(messageContext);
+        } catch (Exception e) {
+            logger.error("Error during mediation of message context", e);
+
+            messageContext.setProperty(SynapseConstants.ERROR_CODE,
+                    PromptDecoratorConstants.APIM_INTERNAL_EXCEPTION_CODE);
+            messageContext.setProperty(SynapseConstants.ERROR_MESSAGE,
+                    "Error occurred during PromptDecorator mediation");
+            Mediator faultMediator = messageContext.getFaultSequence();
+            faultMediator.mediate(messageContext);
+
+            return false; // Stop further processing
+        }
+
+        return true;
+    }
+
+    /**
+     * Locates the payload field using JSONPath and decorates it based on the configured settings.
+     * <p>
+     * Supports both string and array decorations. Updates the payload within the message context.
+     *
+     * @param messageContext The message context containing the JSON payload.
+     * @throws AxisFault If an error occurs while modifying the payload.
+     */
+    private void findAndTransformPayload(MessageContext messageContext) throws AxisFault {
+        if (logger.isDebugEnabled()) {
+            logger.debug( name + " decorating JSON payload.");
+        }
+
+        String jsonContent = extractJsonContent(messageContext);
+        if (jsonContent == null || jsonContent.isEmpty()) {
+            return;
+        }
+
+        // Parse using JsonPath
+        DocumentContext documentContext = JsonPath.parse(jsonContent);
+
+        if (PromptDecoratorConstants.DecorationType.STRING.equals(type)) {
+            // Read the existing string at the path
+            String existingValue = documentContext.read(jsonPath, String.class);
+
+            String updatedValue = !append
+                    ? decoration + " " + existingValue
+                    : existingValue + " " + decoration;
+
+            // Set the new value
+            documentContext.set(jsonPath, updatedValue);
+
+        } else if (PromptDecoratorConstants.DecorationType.ARRAY.equals(type)) {
+            // Read the existing array properly
+            List<Object> existingArray = documentContext.read(jsonPath, new TypeRef<>() {
+            });
+
+            // Parse the decoration into a List<Object>
+            List<Object> decorationList = JsonPath.parse(decoration).read("$", new TypeRef<>() {
+            });
+
+            List<Object> updatedArray = new ArrayList<>();
+
+            if (!append) {
+                updatedArray.addAll(decorationList);
+                updatedArray.addAll(existingArray);
+            } else {
+                updatedArray.addAll(existingArray);
+                updatedArray.addAll(decorationList);
+            }
+
+            // Set the updated array back
+            documentContext.set(jsonPath, updatedArray);
+        } else {
+            logger.warn("Unknown decoration type: " + type);
+        }
+
+        // Update the modified JSON
+        jsonContent = documentContext.jsonString();
+
+
+        // Update the payload
+        org.apache.axis2.context.MessageContext axis2MC =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        JsonUtil.getNewJsonPayload(axis2MC, jsonContent,
+                true, true);
+    }
+
+    /**
+     * Extracts JSON content from the message context.
+     * This utility method converts the Axis2 message payload to a JSON string.
+     *
+     * @param messageContext The message context containing the JSON payload
+     * @return The JSON payload as a string, or null if extraction fails
+     */
+    private String extractJsonContent(MessageContext messageContext) {
+        org.apache.axis2.context.MessageContext axis2MC =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        return JsonUtil.jsonPayloadToString(axis2MC);
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getPromptDecoratorConfig() {
+
+        return promptDecoratorConfig;
+    }
+
+    public void setPromptDecoratorConfig(String promptDecoratorConfig) {
+
+        this.promptDecoratorConfig = promptDecoratorConfig;
+
+        try {
+            Gson gson = new Gson();
+            JsonObject root = gson.fromJson(promptDecoratorConfig, JsonObject.class);
+
+            if (root.has(PromptDecoratorConstants.DECORATION)
+                    && root.get(PromptDecoratorConstants.DECORATION).isJsonArray()) {
+                this.type = PromptDecoratorConstants.DecorationType.ARRAY;
+                this.decoration = root.getAsJsonArray(PromptDecoratorConstants.DECORATION).toString();
+            } else if (root.has(PromptDecoratorConstants.DECORATION)
+                    && root.get(PromptDecoratorConstants.DECORATION).isJsonPrimitive()
+                    && root.get(PromptDecoratorConstants.DECORATION).getAsJsonPrimitive().isString()) {
+                this.type = PromptDecoratorConstants.DecorationType.STRING;
+                this.decoration = root.get(PromptDecoratorConstants.DECORATION).getAsString();
+            } else {
+                throw new IllegalArgumentException(
+                        "Invalid prompt template format: expected 'decoration' as array or string.");
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid prompt template provided: " + promptDecoratorConfig, e);
+        }
+    }
+
+    public boolean isAppend() {
+
+        return append;
+    }
+
+    public void setAppend(boolean append) {
+
+        this.append = append;
+    }
+
+    public String getJsonPath() {
+
+        return jsonPath;
+    }
+
+    public void setJsonPath(String jsonPath) {
+
+        this.jsonPath = jsonPath;
+    }
+}

--- a/mediation/ai/prompt-decorator/universal-gw/prompt-decorator/src/main/java/org/wso2/apim/policies/mediation/ai/prompt/decorator/PromptDecoratorConstants.java
+++ b/mediation/ai/prompt-decorator/universal-gw/prompt-decorator/src/main/java/org/wso2/apim/policies/mediation/ai/prompt/decorator/PromptDecoratorConstants.java
@@ -1,0 +1,30 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.prompt.decorator;
+
+public class PromptDecoratorConstants {
+    public enum DecorationType {
+        STRING,
+        ARRAY
+    }
+    public static final String DECORATION = "decoration";
+    public static final int APIM_INTERNAL_EXCEPTION_CODE = 900967;
+}

--- a/mediation/ai/prompt-decorator/universal-gw/resources/artifact.j2
+++ b/mediation/ai/prompt-decorator/universal-gw/resources/artifact.j2
@@ -1,0 +1,6 @@
+<class name="org.wso2.apim.policies.mediation.ai.prompt.decorator.PromptDecorator">
+    <property action="set" name="name" value="{{name}}"/>
+    <property action="set" name="promptDecoratorConfig" value="{{promptDecoratorConfig}}"/>
+    <property action="set" name="jsonPath" value="{{jsonPath}}"/>
+    <property action="set" name="append" type="BOOLEAN" value="{{append}}"/>
+</class>

--- a/mediation/ai/prompt-decorator/universal-gw/resources/policy-definition.json
+++ b/mediation/ai/prompt-decorator/universal-gw/resources/policy-definition.json
@@ -1,0 +1,55 @@
+{
+  "category": "Mediation",
+  "name": "PromptDecorator",
+  "displayName": "Prompt Decorator",
+  "version": "v1.0",
+  "description": "Dynamically modifies the prompt by applying custom decorations using a configured strategy.",
+  "applicableFlows": [
+    "request"
+  ],
+  "supportedApiTypes": [
+    {
+      "subType": "AIAPI",
+      "apiType": "HTTP"
+    }
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "policyAttributes": [
+    {
+      "name": "name",
+      "displayName": "Decorator Name",
+      "description": "The name of the prompt decorator policy. Used for tracking and referencing this policy instance.",
+      "type": "String",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "promptDecoratorConfig",
+      "displayName": "Prompt Decorator Configuration",
+      "description": "The configuration for decorating the prompt. Can decorate completions or chat/completions definitions.",
+      "type": "JSON",
+      "defaultValue": "{\n  \"decoration\": [\n    {\n      \"role\": \"\",\n      \"content\": \"\"\n    }\n  ]\n}",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "jsonPath",
+      "displayName": "JSON Path",
+      "description": "The JSONPath expression to extract the portion of the prompt that should be modified.",
+      "type": "String",
+      "defaultValue": "$.messages",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "append",
+      "displayName": "Append Decorated Content",
+      "description": "If true, the decorated content will be appended to the prompt instead of replacing it.",
+      "type": "Boolean",
+      "allowedValues": [],
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Implement a mediation policy that enables dynamic prompt modification within the API Gateway by applying custom decorations using a configurable strategy.

## Approach
Develop a custom Synapse mediator (`PromptDecorator`) that decorates the prompt content based on api creator defined configuration. The decoration can either be a `chat/completions` json array of role-based messages or `completions` plain string template.

The decorator supports extracting and modifying a specific portion of the prompt using a JSONPath expression. It allows appending or prepending the decorated content, based on the `append` flag.

This policy is only applicable to the **request flow** of AI APIs and is designed to standardize prompt enrichment across multiple use cases.
