### PR TITLE
Implement Prompt Template Policy

### DIFF
--- a/mediation/ai/prompt-templat/universal-gw/prompt-template/assembly-zip.xml
+++ b/mediation/ai/prompt-templat/universal-gw/prompt-template/assembly-zip.xml
@@ -1,0 +1,27 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>distribution</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <!-- Include the JAR -->
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+        <!-- Include the ../resources directory -->
+        <fileSet>
+            <directory>${basedir}/../resources</directory>
+            <outputDirectory>./</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/mediation/ai/prompt-templat/universal-gw/prompt-template/pom.xml
+++ b/mediation/ai/prompt-templat/universal-gw/prompt-template/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.apim.policies</groupId>
+    <artifactId>org.wso2.apim.policies.mediation.ai.prompt-template</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>WSO2 APIM Mediation Policies - AI Prompt Template</name>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <org.apache.felix.version>3.3.0</org.apache.felix.version>
+        <synapse.version>4.0.0-wso2v131</synapse.version>
+        <jackson.version>2.19.0</jackson.version>
+        <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
+        <json.orbit.version>3.0.0.wso2v6</json.orbit.version>
+        <import.package.version.commons.logging>[1.2.0,2.0.0)</import.package.version.commons.logging>
+        <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
+    </properties>
+
+    <dependencies>
+        <!-- Synapse Dependencies -->
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>${synapse.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jackson for JSON Processing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- JSON Library -->
+        <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+            <version>${json.orbit.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.orbit.com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>${com.jayway.jsonpath.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Compiler Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${org.apache.felix.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.wso2.apim.policies.mediation.ai.prompt.template;version="${project.version}",
+                        </Export-Package>
+                        <Import-Package>
+                            !com.jayway.jsonpath.*,
+                            !net.minidev.json.*,
+                            !net.minidev.asm.*,
+                            !org.json.*,
+                            org.apache.axis2; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.description; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.engine; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.rpc.receivers; version="${axis2.osgi.version.range}",
+                            org.apache.axis2.context; version="${axis2.osgi.version.range}",
+                            org.apache.commons.logging.*; version="${import.package.version.commons.logging}",
+                            org.apache.synapse,
+                            org.apache.synapse.config,
+                            org.apache.synapse.config.xml,
+                            org.apache.synapse.core,
+                            org.apache.synapse.core.axis2,
+                            org.apache.synapse.mediators.base,
+                            org.apache.axis2.transport.base,
+                            org.apache.synapse.*,
+                            *;resolution:=optional
+                        </Import-Package>
+                        <Embed-Dependency>
+                            json;scope=compile|runtime,
+                            json-path;scope=compile|runtime
+                        </Embed-Dependency>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase> <!-- Runs after the JAR is built -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>assembly-zip.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+</project>

--- a/mediation/ai/prompt-templat/universal-gw/prompt-template/src/main/java/org/wso2/apim/policies/mediation/ai/prompt/template/PromptTemplate.java
+++ b/mediation/ai/prompt-templat/universal-gw/prompt-template/src/main/java/org/wso2/apim/policies/mediation/ai/prompt/template/PromptTemplate.java
@@ -1,0 +1,287 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.prompt.template;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.axis2.AxisFault;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.synapse.ManagedLifecycle;
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.AbstractMediator;
+
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * PromptTemplate mediator.
+ * <p>
+ * <p>
+ * The PromptTemplate mediator scans JSON payloads for template references in the format
+ * {@code template://<template-name>?<param1>=<value1>&<param2>=<value2>} and replaces them
+ * with predefined templates where parameter placeholders are substituted with provided values.
+ * This is particularly useful for standardizing prompts across different API calls, especially
+ * when working with large language models or AI services.
+ * <p>
+ * Template references in the payload are processed using regex pattern matching and URI parsing.
+ * Each template placeholder in the format {@code [[parameter-name]]} is replaced with the
+ * corresponding parameter value from the template URI query string.
+ * <p>
+ * Configuration is provided through a JSON array of template objects, each containing a name and
+ * prompt definition:
+ * <pre>
+ * [
+ *   {
+ *     "name": "translate",
+ *     "prompt": "Translate the following text from [[from]] to [[to]]: [[text]]"
+ *   },
+ *   {
+ *     "name": "summarize",
+ *     "prompt": "Summarize the following content in [[length]] words: [[content]]"
+ *   }
+ * ]
+ * </pre>
+ * <p>
+ * Example usage in a payload:
+ * <pre>
+ * {
+ *   "messages": [
+ *     {
+ *       "role": "user",
+ *       "content": "template://translate?from=english&to=spanish&text=Hello world"
+ *     }
+ *   ]
+ * }
+ * </pre>
+ * <p>
+ * The mediator would transform this to:
+ * <pre>
+ * {
+ *   "messages": [
+ *     {
+ *       "role": "user",
+ *       "content": "Translate the following text from english to spanish: Hello world"
+ *     }
+ *   ]
+ * }
+ * </pre>
+ */
+public class PromptTemplate extends AbstractMediator implements ManagedLifecycle {
+    private static final Log logger = LogFactory.getLog(PromptTemplate.class);
+
+    private String name;
+    private String promptTemplateConfig;
+    private final Map<String, String> promptTemplates = new HashMap<>();
+
+    /**
+     * Initializes the PromptTemplate mediator.
+     *
+     * @param synapseEnvironment The Synapse environment instance.
+     */
+    @Override
+    public void init(SynapseEnvironment synapseEnvironment) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Initializing PromptTemplate.");
+        }
+    }
+
+    /**
+     * Destroys the PromptTemplate mediator instance and releases any allocated resources.
+     */
+    @Override
+    public void destroy() {
+        // No specific resources to release
+    }
+
+    /**
+     * Mediates the message context by transforming the payload using prompt templates.
+     * <p>
+     * This method looks for placeholders in the JSON payload that match the predefined templates, and replaces
+     * them with the appropriate values. It logs the mediation progress and handles any exceptions that occur during
+     * the mediation process.
+     *
+     * @param messageContext The message context containing the JSON payload to be mediated.
+     * @return {@code true} to continue the mediation process.
+     */
+    @Override
+    public boolean mediate(MessageContext messageContext) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Mediating message context with prompt templates.");
+        }
+
+        try {
+            findAndTransformPayload(messageContext);
+        } catch (Exception e) {
+            logger.error("Error during mediation of message context", e);
+
+            messageContext.setProperty(SynapseConstants.ERROR_CODE,
+                    PromptTemplateConstants.APIM_INTERNAL_EXCEPTION_CODE);
+            messageContext.setProperty(SynapseConstants.ERROR_MESSAGE,
+                    "Error occurred during PromptTemplate mediation");
+            Mediator faultMediator = messageContext.getFaultSequence();
+            faultMediator.mediate(messageContext);
+
+            return false; // Stop further processing
+        }
+
+        return true;
+    }
+
+    /**
+     * Finds and transforms the payload in the message context by resolving template placeholders.
+     * <p>
+     * This method searches the JSON content for template placeholders in the form of
+     * {@code template://<template-name>?<params>} and replaces them with the corresponding template values.
+     *
+     * @param messageContext The message context containing the JSON payload.
+     * @throws AxisFault If an error occurs while modifying the payload.
+     */
+    private void findAndTransformPayload(MessageContext messageContext) throws AxisFault {
+        if (logger.isDebugEnabled()) {
+            logger.debug(this.name + "applying prompt templates.");
+        }
+
+        String jsonContent = extractJsonContent(messageContext);
+        if (jsonContent == null || jsonContent.isEmpty()) {
+            return;
+        }
+
+        String updatedJsonContent = jsonContent;
+
+        // Regex to find template://<template-name>?<params>
+        Pattern pattern = Pattern.compile(PromptTemplateConstants.PROMPT_TEMPLATE_REGEX);
+        Matcher matcher = pattern.matcher(jsonContent);
+
+        while (matcher.find()) {
+            String matched = matcher.group(); // ex: template://translate?from=english&to=spanish
+
+            try {
+                // Parse the matched string as a URI
+                URI uri = new URI(matched);
+                String templateName = uri.getHost(); // translate
+                String query = uri.getQuery(); // from=english&to=spanish
+
+                if (promptTemplates.containsKey(templateName)) {
+                    String template = promptTemplates.get(templateName);
+
+                    // Parse query parameters
+                    Map<String, String> params = new HashMap<>();
+                    if (query != null) {
+                        String[] pairs = query.split("&");
+                        for (String pair : pairs) {
+                            String[] keyValue = pair.split("=", 2);
+                            if (keyValue.length == 2) {
+                                String key = URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8);
+                                String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
+                                params.put(key, value);
+                            }
+                        }
+                    }
+
+                    // Replace placeholders in template
+                    String resolvedPrompt = template;
+                    for (Map.Entry<String, String> entry : params.entrySet()) {
+                        String placeholder = "[[" + entry.getKey() + "]]";
+                        resolvedPrompt = resolvedPrompt.replace(placeholder, entry.getValue());
+                    }
+
+                    // Directly replace in updatedJsonContent
+                    updatedJsonContent = updatedJsonContent.replace(matched, resolvedPrompt);
+                } else {
+                    logger.warn("No prompt template found for: " + templateName);
+                }
+            } catch (Exception e) {
+                logger.error("Error while transforming template for match: " + matched, e);
+            }
+        }
+
+        // Update the payload
+        org.apache.axis2.context.MessageContext axis2MC =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        JsonUtil.getNewJsonPayload(axis2MC, updatedJsonContent,
+                true, true);
+    }
+
+    /**
+     * Extracts the JSON content from the provided message context.
+     * <p>
+     * This method retrieves the JSON payload from the message context and returns it as a string.
+     *
+     * @param messageContext The message context containing the JSON payload.
+     * @return The extracted JSON content as a string, or {@code null} if no JSON content is found.
+     */
+    public static String extractJsonContent(MessageContext messageContext) {
+        org.apache.axis2.context.MessageContext axis2MC =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        return JsonUtil.jsonPayloadToString(axis2MC);
+    }
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getPromptTemplateConfig() {
+
+        return promptTemplateConfig;
+    }
+
+    public void setPromptTemplateConfig(String promptTemplateConfig) {
+
+        this.promptTemplateConfig = promptTemplateConfig;
+
+        try {
+            Gson gson = new Gson();
+            Type listType = new TypeToken<List<Map<String, String>>>() {}.getType();
+            List<Map<String, String>> templates = gson.fromJson(promptTemplateConfig, listType);
+
+            for (Map<String, String> item : templates) {
+                String templateName = item.get(PromptTemplateConstants.PROMPT_TEMPLATE_NAME);
+                String templatePrompt = item.get(PromptTemplateConstants.PROMPT_TEMPLATE_PROMPT);
+                if (templateName == null || templatePrompt == null) {
+                    throw new IllegalArgumentException(
+                            "Prompt template must include both 'name' and 'prompt': " + item);
+                }
+                promptTemplates.put(templateName, templatePrompt);
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid prompt template provided: " + promptTemplateConfig, e);
+        }
+    }
+}

--- a/mediation/ai/prompt-templat/universal-gw/prompt-template/src/main/java/org/wso2/apim/policies/mediation/ai/prompt/template/PromptTemplateConstants.java
+++ b/mediation/ai/prompt-templat/universal-gw/prompt-template/src/main/java/org/wso2/apim/policies/mediation/ai/prompt/template/PromptTemplateConstants.java
@@ -1,0 +1,28 @@
+/*
+ *
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.wso2.apim.policies.mediation.ai.prompt.template;
+
+public class PromptTemplateConstants {
+    public static final String PROMPT_TEMPLATE_REGEX = "template://[a-zA-Z0-9_-]+\\?[^\\s\"']*";
+    public static final String PROMPT_TEMPLATE_NAME = "name";
+    public static final String PROMPT_TEMPLATE_PROMPT = "prompt";
+    public static final int APIM_INTERNAL_EXCEPTION_CODE = 900967;
+}

--- a/mediation/ai/prompt-templat/universal-gw/resources/artifact.j2
+++ b/mediation/ai/prompt-templat/universal-gw/resources/artifact.j2
@@ -1,0 +1,4 @@
+<class name="org.wso2.apim.policies.mediation.ai.prompt.template.PromptTemplate">
+    <property action="set" name="name" value="{{name}}"/>
+    <property action="set" name="promptTemplateConfig" value="{{promptTemplateConfig}}"/>
+</class>

--- a/mediation/ai/prompt-templat/universal-gw/resources/policy-definition.json
+++ b/mediation/ai/prompt-templat/universal-gw/resources/policy-definition.json
@@ -1,0 +1,38 @@
+{
+  "category": "Mediation",
+  "name": "PromptTemplate",
+  "displayName": "Prompt Template",
+  "version": "v1.0",
+  "description": "Dynamically modifies the prompt by applying custom templates using a configured strategy.",
+  "applicableFlows": [
+    "request"
+  ],
+  "supportedApiTypes": [
+    {
+      "subType": "AIAPI",
+      "apiType": "HTTP"
+    }
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "policyAttributes": [
+    {
+      "name": "name",
+      "displayName": "Template Name",
+      "description": "The name of the prompt template policy. Used for tracking and referencing this policy instance.",
+      "type": "String",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "promptTemplateConfig",
+      "displayName": "Prompt Template Configuration",
+      "description": "The configuration that defines one or more prompt templates to be used during request mediation. Each template includes a unique name and a corresponding formatted prompt.",
+      "type": "JSON",
+      "defaultValue": "[\n  {\n    \"name\": \"\",\n    \"prompt\": \"\"\n  }\n]",
+      "allowedValues": [],
+      "required": true
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Implement a mediation policy that enables dynamic prompt transformation within the API Gateway by applying predefined templates through a configurable strategy.

## Approach
Developed a custom Synapse mediator (`PromptTemplate`) that injects prompt templates based on configuration defined by the API creator. This policy detects specific patterns in the client request that correspond to placeholder values within the template. Once matched, the mediator replaces the original prompt content with the transformed version and forwards the updated payload to the LLM service.

This policy is applicable exclusively to the **request flow** of AI APIs and is intended to standardize prompt enrichment across a variety of use cases.

