### PR TITLE
Fix response not getting cached

### DIFF
--- a/mediation/ai/semantic-cache/universal-gw/semantic-cache/src/main/java/org/wso2/apim/policies/mediation/ai/semantic/cache/SemanticCache.java
+++ b/mediation/ai/semantic-cache/universal-gw/semantic-cache/src/main/java/org/wso2/apim/policies/mediation/ai/semantic/cache/SemanticCache.java
@@ -187,13 +187,10 @@ public class SemanticCache extends AbstractMediator implements ManagedLifecycle 
         filter.put(SemanticCacheConstants.THRESHOLD, threshold);
 
         String retrievedResponse = vectorDBProvider.retrieve(embeddings, filter);
-        if (retrievedResponse == null) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("No cached response found for the request embeddings.");
-            }
-            return true; // No cache hit, continue processing
+        CacheableResponse cachedResponse = null;
+        if (retrievedResponse != null) {
+            cachedResponse = gson.fromJson(retrievedResponse, CacheableResponse.class);
         }
-        CacheableResponse cachedResponse = gson.fromJson(retrievedResponse, CacheableResponse.class);
         if (cachedResponse != null && cachedResponse.getResponsePayload() != null) {
             messageContext.setResponse(true);
             replaceEnvelopeWithCachedResponse(messageContext, msgCtx, cachedResponse);


### PR DESCRIPTION
In semantic cache, currently if there is no cache hit, it will return without saving the response. This PR fixes that issue.