### PR TITLE
Fix RegexGuardrail to skip validation for non-2xx responses

### DIFF
--- a/mediation/ai/regex-guardrail/universal-gw/regex-guardrail/pom.xml
+++ b/mediation/ai/regex-guardrail/universal-gw/regex-guardrail/pom.xml
@@ -87,6 +87,39 @@
             <artifactId>json-path</artifactId>
             <version>${com.jayway.jsonpath.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.5.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>2.0.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -98,6 +131,20 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.util.regex=ALL-UNNAMED
+                        --add-opens java.base/java.io=ALL-UNNAMED
+                        --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
 

--- a/mediation/ai/regex-guardrail/universal-gw/regex-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/regex/guardrail/RegexGuardrail.java
+++ b/mediation/ai/regex-guardrail/universal-gw/regex-guardrail/src/main/java/org/wso2/apim/policies/mediation/ai/regex/guardrail/RegexGuardrail.java
@@ -79,6 +79,20 @@ public class RegexGuardrail extends AbstractMediator implements ManagedLifecycle
             logger.debug("Beginning payload validation.");
         }
 
+        if (messageContext.isResponse()) {
+            Object httpSC = ((Axis2MessageContext) messageContext).getAxis2MessageContext()
+                    .getProperty("HTTP_SC");
+            if (httpSC instanceof Number) {
+                int statusCode = ((Number) httpSC).intValue();
+                if (statusCode < 200 || statusCode >= 300) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Skipping guardrail validation for non-2xx response: " + statusCode);
+                    }
+                    return true;
+                }
+            }
+        }
+
         try {
             boolean validationResult = validatePayload(messageContext);
             boolean finalResult = invert != validationResult;

--- a/mediation/ai/regex-guardrail/universal-gw/regex-guardrail/src/test/java/org/wso2/apim/policies/mediation/ai/regex/guardrail/RegexGuardrailTest.java
+++ b/mediation/ai/regex-guardrail/universal-gw/regex-guardrail/src/test/java/org/wso2/apim/policies/mediation/ai/regex/guardrail/RegexGuardrailTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apim.policies.mediation.ai.regex.guardrail;
+
+import org.apache.synapse.Mediator;
+import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@PrepareForTest({RegexGuardrail.class})
+@RunWith(PowerMockRunner.class)
+public class RegexGuardrailTest {
+
+    private Axis2MessageContext messageContext;
+    private org.apache.axis2.context.MessageContext axis2MsgContext;
+    private RegexGuardrail guardrail;
+    private Mediator faultMediator;
+
+    @Before
+    public void init() throws Exception {
+        messageContext = Mockito.mock(Axis2MessageContext.class);
+        axis2MsgContext = Mockito.mock(org.apache.axis2.context.MessageContext.class);
+        faultMediator = Mockito.mock(Mediator.class);
+
+        Mockito.when(messageContext.getAxis2MessageContext()).thenReturn(axis2MsgContext);
+        Mockito.when(messageContext.getFaultSequence()).thenReturn(faultMediator);
+        Mockito.when(faultMediator.mediate(Mockito.any(MessageContext.class))).thenReturn(true);
+
+        guardrail = PowerMockito.spy(new RegexGuardrail());
+        guardrail.setRegex("(?i)(forbidden|restricted|blocked)");
+        guardrail.setJsonPath("$['choices']");
+        guardrail.setInvert(true);
+        guardrail.setName("TestRegexGuardrail");
+        guardrail.setShowAssessment(true);
+    }
+
+    private void mockExtractJsonContent(String payload) throws Exception {
+        PowerMockito.doReturn(payload).when(guardrail, "extractJsonContent", Mockito.any(MessageContext.class));
+    }
+
+    @Test
+    public void testSkipsValidationFor401Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(401);
+
+        Assert.assertTrue("Should pass through 401 response without validation",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testSkipsValidationFor403Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(403);
+
+        Assert.assertTrue("Should pass through 403 response without validation",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testSkipsValidationFor500Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(500);
+
+        Assert.assertTrue("Should pass through 500 response without validation",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testSkipsValidationFor502Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(502);
+
+        Assert.assertTrue("Should pass through 502 response without validation",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testSkipsValidationFor503Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(503);
+
+        Assert.assertTrue("Should pass through 503 response without validation",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testSkipsValidationFor400Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(400);
+
+        Assert.assertTrue("Should pass through 400 response without validation",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testSkipsValidationFor404Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(404);
+
+        Assert.assertTrue("Should pass through 404 response without validation",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testSkipsValidationForBoundary199Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(199);
+
+        Assert.assertTrue("Should skip validation for 199 response (below 2xx range)",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testSkipsValidationForBoundary300Response() {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(300);
+
+        Assert.assertTrue("Should skip validation for 300 response (above 2xx range)",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testProcessesValidationFor200Response() throws Exception {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(200);
+
+        String payload = "{\"choices\":[{\"message\":{\"content\":\"Hello world\"}}]}";
+        mockExtractJsonContent(payload);
+
+        Assert.assertTrue("Should process and pass 200 response with valid content",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testProcessesValidationFor201Response() throws Exception {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(201);
+
+        String payload = "{\"choices\":[{\"message\":{\"content\":\"Hello world\"}}]}";
+        mockExtractJsonContent(payload);
+
+        Assert.assertTrue("Should process and pass 201 response with valid content",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testValidationFailsFor200WithViolatingContent() throws Exception {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(200);
+        Mockito.when(messageContext.getSequence(RegexGuardrailConstants.FAULT_SEQUENCE_KEY)).thenReturn(faultMediator);
+
+        String payload = "{\"choices\":[{\"message\":{\"content\":\"This is forbidden content\"}}]}";
+        mockExtractJsonContent(payload);
+
+        Assert.assertFalse("Should fail validation for 200 response with violating content",
+                guardrail.mediate(messageContext));
+        Mockito.verify(messageContext).setProperty(
+                Mockito.eq(SynapseConstants.ERROR_CODE),
+                Mockito.eq(RegexGuardrailConstants.GUARDRAIL_APIM_EXCEPTION_CODE));
+    }
+
+    @Test
+    public void testRequestMessageStillValidates() throws Exception {
+        Mockito.when(messageContext.isResponse()).thenReturn(false);
+
+        String payload = "{\"messages\":[{\"content\":\"Hello world\"}]}";
+        mockExtractJsonContent(payload);
+
+        guardrail.setJsonPath("");
+        Assert.assertTrue("Request messages should still be validated (no regex match = pass with invert)",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testRequestMessageValidationFailsOnViolation() throws Exception {
+        Mockito.when(messageContext.isResponse()).thenReturn(false);
+        Mockito.when(messageContext.getSequence(RegexGuardrailConstants.FAULT_SEQUENCE_KEY)).thenReturn(faultMediator);
+
+        String payload = "{\"messages\":[{\"content\":\"This is forbidden\"}]}";
+        mockExtractJsonContent(payload);
+
+        guardrail.setJsonPath("");
+        Assert.assertFalse("Request with violating content should fail validation",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testNullHttpScProceedsWithValidation() throws Exception {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(null);
+
+        String payload = "{\"choices\":[{\"message\":{\"content\":\"Hello world\"}}]}";
+        mockExtractJsonContent(payload);
+
+        Assert.assertTrue("Should proceed with validation when HTTP_SC is null",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testEmptyPayloadWithInvertTrue() throws Exception {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(200);
+        mockExtractJsonContent("");
+
+        // validatePayload returns false (empty), invert(true) != false => finalResult=true
+        Assert.assertTrue("Empty payload with invert=true should pass through",
+                guardrail.mediate(messageContext));
+    }
+
+    @Test
+    public void testNullPayloadWithInvertTrue() throws Exception {
+        Mockito.when(messageContext.isResponse()).thenReturn(true);
+        Mockito.when(axis2MsgContext.getProperty("HTTP_SC")).thenReturn(200);
+        mockExtractJsonContent(null);
+
+        // validatePayload returns false (null), invert(true) != false => finalResult=true
+        Assert.assertTrue("Null payload with invert=true should pass through",
+                guardrail.mediate(messageContext));
+    }
+}


### PR DESCRIPTION
## Summary

When an AI API's backend LLM provider returns a non-2xx error response (e.g., HTTP 401 Unauthorized due to an expired API key), the RegexGuardrail mediator crashes with `PathNotFoundException` because the error response body doesn't contain the expected JSON structure (e.g., `$['choices']`). This triggers the fault sequence and the gateway returns HTTP 500 with error code 900967 ("Error occurred during RegexGuardrail mediation"), completely masking the real backend error.

**Root Cause:** `RegexGuardrail.mediate()` unconditionally calls `validatePayload()` → `JsonPath.read(content, jsonPath)` on every response, including error responses. When the configured `jsonPath` (e.g., `$['choices']`) doesn't exist in the error response body (e.g., `{"detail":"Unauthorized"}`), `PathNotFoundException` is thrown and caught by the generic exception handler, which sets error code 900967 and invokes the fault sequence.

**Fix:** Add an HTTP status code check at the beginning of `mediate()` for response messages. If the backend response is non-2xx, the guardrail returns `true` (pass-through) without attempting validation, allowing the original error response to propagate to the client.

## Changes

- **`RegexGuardrail.java`**: Added status code guard in `mediate()` — checks `isResponse()` and `HTTP_SC`, skips validation for non-2xx responses.
- **`pom.xml`**: Added test dependencies (JUnit 4, Mockito, PowerMock) and surefire `--add-opens` args for Java 21 compatibility.
- **`RegexGuardrailTest.java`** (new): 17 unit tests covering:
  - Non-2xx bypass (401, 400, 403, 404, 500, 502, 503, boundary 199/300)
  - 2xx processing preserved (200, 201, violation detection)
  - Request flow unaffected (requests still validate regardless of status code)
  - Edge cases (null HTTP_SC, empty/null payload)

> **Note:** This is the primary fix for issue #16458. A companion fix in `carbon-apimgt` (AIAPIMediator) moves the status code check before metadata extraction.

## Verification

- Extracted fresh APIM 4.6.0 pack, applied both patched JARs
- **Test 1 (401 backend):** Gateway correctly returns HTTP 401 with original error body. Previously returned HTTP 500 with error 900967.
- **Test 2 (200 backend):** Gateway correctly returns HTTP 200 with valid chat completion — guardrail still validates 2xx responses.
- **Test 3 (429 backend):** Gateway correctly returns HTTP 429 with rate limit error — non-2xx pass-through works.
- Server logs show zero RegexGuardrail errors after all invocations.

## Test plan
- [x] Unit tests for non-2xx bypass (7 status codes + 2 boundary cases)
- [x] Unit tests for 2xx validation preserved (200, 201, violation detection)
- [x] Unit tests for request flow unaffected
- [x] Integration test with mock backend returning 401, 200, 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)